### PR TITLE
Fix: Handle note 0 messages too

### DIFF
--- a/src/hydra-api/note.ts
+++ b/src/hydra-api/note.ts
@@ -14,7 +14,7 @@ export const getNoteId = (
   input?: InputArg,
 ): NoteId =>
   getMidiId(
-    note ? resolveNote(note) : undefined,
+    note !== undefined ? resolveNote(note) : undefined,
     channel ?? state.defaults.channel,
     resolveInput(input ?? state.defaults.input),
   )


### PR DESCRIPTION
Currently, if you use some that device that happens to have note 0 messages (this is my case with an Akai APC Mini Mk2), hydra-midi can't interpret the 0 proper, as it is falsey and `getMidiId` has a check over `note`

before
```ts
getMidiId(
    note ? resolveNote(note) : undefined,
    channel ?? state.defaults.channel,
    resolveInput(input ?? state.defaults.input),
)
```

after
```ts
getMidiId(
    note !== undefined ? resolveNote(note) : undefined,
    channel ?? state.defaults.channel,
    resolveInput(input ?? state.defaults.input),
)
```